### PR TITLE
BA-1459: Disallow unsupported image types in Create/Edit static page

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Noel O'Connell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/quill.imageUploader.js
+++ b/src/quill.imageUploader.js
@@ -29,7 +29,7 @@ class ImageUploader {
         this.range = this.quill.getSelection();
         this.fileHolder = document.createElement("input");
         this.fileHolder.setAttribute("type", "file");
-        this.fileHolder.setAttribute("accept", "image/*");
+        this.fileHolder.setAttribute("accept", this.options.accept.startsWith("image") ? this.options.accept : "image/*");   
         this.fileHolder.setAttribute("style", "visibility:hidden");
 
         this.fileHolder.onchange = this.fileChanged.bind(this);


### PR DESCRIPTION
**What this PR does / why we need it**:

Only allow images, no other file types (including no videos).

**Demo**:
![Screenshot 2024-05-31 at 8 46 08 AM](https://github.com/brandarmy/quill-image-uploader/assets/22037563/8f8e12f4-6c7a-40a4-8e4d-bb0cb28c3dc5)
